### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/getting-started.js"
 --8<-- "snippets/grail-requirements.md"
 
 ## Prerequisites before launching the Codespace

--- a/docs/3-codespaces.md
+++ b/docs/3-codespaces.md
@@ -1,4 +1,3 @@
---8<-- "snippets/3-codespaces.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/4-content.md
+++ b/docs/4-content.md
@@ -1,5 +1,4 @@
 # Content
---8<-- "snippets/4-content.js"
 
 ## What is AI and LLM observability?
 AI and Large Language Model (LLM) observability provides visibility into all layers AI-powered applications.

--- a/docs/5-direct.md
+++ b/docs/5-direct.md
@@ -1,5 +1,4 @@
 # Direct Chat
---8<-- "snippets/5-direct.js"
 
 In this mode, we directly send our prompt to Ollama to generate a travel raccomendation.
 Let's use `Sydney` as city to test the AI Travel raccomendation and press `Advise`.

--- a/docs/6-rag.md
+++ b/docs/6-rag.md
@@ -1,5 +1,4 @@
 # Retrieval-Augmented Generation (RAG) 
---8<-- "snippets/6-rag.js"
 
 Retrieval-Augmented Generation (RAG) is a technique that provides additional context to LLMs to have additional information to carry out a solution to the prompt they receive.
 In our AI Travel Advisor App, the RAG pipeline is built using LangChain. The retrieval step reaches out to Weaviate to query for documents relevant to the prompt in input.

--- a/docs/7-agentic.md
+++ b/docs/7-agentic.md
@@ -1,5 +1,4 @@
 # Agentic AI
---8<-- "snippets/7-agentic.js"
 
 Agentic AI is a novel technique where AI systems act independently and proactively, aiming to achieve specific goals without direct human intervention.
 Integrating these systems into digital services poses challenges due to their non-deterministic communication, which can create unpredictable behavior.

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/cleanup.js"
 
 
 !!! tip "Deleting the codespace from inside the container"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/index.js"
 
 --8<-- "snippets/disclaimer.md"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,4 +1,3 @@
---8<-- "snippets/resources.js"
 
 ### Get your Dynatrace environment
 

--- a/docs/snippets/2-getting-started.js
+++ b/docs/snippets/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"});
-});
-</script>

--- a/docs/snippets/3-codespaces.js
+++ b/docs/snippets/3-codespaces.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Codespaces"});
-});
-</script>

--- a/docs/snippets/4-content.js
+++ b/docs/snippets/4-content.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Content"});
-});
-</script>

--- a/docs/snippets/5-direct.js
+++ b/docs/snippets/5-direct.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Direct Chat"});
-});
-</script>

--- a/docs/snippets/6-rag.js
+++ b/docs/snippets/6-rag.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. RAG"});
-});
-</script>

--- a/docs/snippets/7-agentic.js
+++ b/docs/snippets/7-agentic.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. Agentic"});
-});
-</script>

--- a/docs/snippets/cleanup.js
+++ b/docs/snippets/cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "8. Cleanup"});
-});
-</script>

--- a/docs/snippets/index.js
+++ b/docs/snippets/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"});
-});
-</script>

--- a/docs/snippets/resources.js
+++ b/docs/snippets/resources.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "9. Resources"});
-});
-</script>

--- a/docs/snippets/whats-next.js
+++ b/docs/snippets/whats-next.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "10. What's next?"});
-});
-</script>

--- a/docs/whats-next.md
+++ b/docs/whats-next.md
@@ -1,4 +1,3 @@
---8<-- "snippets/whats-next.js"
 
 --8<-- "snippets/feedback.md"
 


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)