### PR TITLE
fix(post-create): remove weaviate storageClass sed workaround

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -9,10 +9,6 @@ startK3dCluster
 
 installK9s
 
-# k3d uses "local-path" StorageClass; framework cache may still have "standard"
-sed -i 's/storageClassName: "standard"/storageClassName: "local-path"/g' \
-  "${FRAMEWORK_APPS_PATH}/ai-travel-advisor/k8s/weaviate.yaml" 2>/dev/null || true
-
 deployAITravelAdvisorApp
 
 


### PR DESCRIPTION
## Summary

- Remove the `sed` patch from `post-create.sh` that rewrote `storageClassName: "standard"` → `"local-path"` in the framework's `weaviate.yaml` at Codespace creation time

## Context

The patch was added because the framework's `weaviate.yaml` originally shipped with `storageClassName: "standard"`, which doesn't exist in K3d (K3d uses `local-path`). The root cause was fixed upstream in [codespaces-framework#49](https://github.com/dynatrace-wwse/codespaces-framework/pull/49), which updated `weaviate.yaml` to use `local-path` directly.

A dedicated framework regression test (`integration_k3d_aitraveladvisor.sh`) was added in [codespaces-framework#54](https://github.com/dynatrace-wwse/codespaces-framework/pull/54) to guard against this StorageClass regressing again.

## Test plan

- [x] Framework `weaviate.yaml` confirms `storageClassName: "local-path"` since framework v1.3.x (#49)
- [x] Framework integration test `k3d-aitraveladvisor` guards against regression
- [x] Verify Codespace creation succeeds without the sed workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)