### PR TITLE
chore: forward ingress port 80 instead of legacy NodePort 30100

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,11 +33,11 @@
   },
   	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		30100
+		80
 	],
 	// add labels
 	"portsAttributes": {
-		"30100": { "label": "Application Web UI" }
+		"80": { "label": "Application Web UI (nginx ingress)" }
 	},
   // minimal CPU when running DT components and apps.
 	"hostRequirements": {


### PR DESCRIPTION
Migrates app exposure to nginx ingress ahead of framework 1.5.0 (NodePort path removed). See dynatrace-wwse/codespaces-framework#55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)